### PR TITLE
feat: reduce initramfs size

### DIFF
--- a/Dockerfile.yunionos-vm
+++ b/Dockerfile.yunionos-vm
@@ -1,0 +1,25 @@
+FROM registry.cn-beijing.aliyuncs.com/yunionio/onecloud-base:v0.3.5
+
+RUN mkdir -p /yunionos/x86_64 && mkdir -p /yunionos/aarch64
+
+# ADD x86_64 kernel and initramfs
+ADD ./output_bundle_vm/kernel /yunionos/x86_64
+ADD ./output_bundle_vm/initramfs /yunionos/x86_64
+
+# ADD arm64 kernel and initramfs
+ADD ./output_bundle_arm64_vm/kernel /yunionos/aarch64
+ADD ./output_bundle_arm64_vm/initramfs /yunionos/aarch64
+
+# ADD syslinux firmwares
+ADD ./output_bundle/isolinux.bin /yunionos/x86_64
+ADD ./output_bundle/chain.c32 /yunionos/x86_64
+ADD ./output_bundle/ldlinux.c32 /yunionos/x86_64
+ADD ./output_bundle/ldlinux.e32 /yunionos/x86_64
+ADD ./output_bundle/ldlinux.e64 /yunionos/x86_64
+ADD ./output_bundle/libutil.c32 /yunionos/x86_64
+ADD ./output_bundle/libcom32.c32 /yunionos/x86_64
+ADD ./output_bundle/bootia32.efi /yunionos/x86_64
+ADD ./output_bundle/bootx64.efi /yunionos/x86_64
+ADD ./output_bundle/lpxelinux.0 /yunionos/x86_64
+ADD ./output_bundle/pxelinux.0 /yunionos/x86_64
+ADD ./output_bundle/menu.c32 /yunionos/x86_64

--- a/README.md
+++ b/README.md
@@ -3,6 +3,23 @@ Cloudpods PXE／ISO ROM scripts
 
 ## 使用方法
 
+### 快速编译 yunionos image
+
+这里只说快速制作出 yunionos 容器镜像，其他详细步骤见后面的文档内容。
+
+1. 下载内核和firmware，本地有可跳过:
+
+```bash
+# 下载内核
+$ make download-kernel-6-deb
+```
+
+2. 制作 yunionos 镜像
+
+```bash
+$ make docker-yunionos-image-all
+```
+
 ### 编译 rootfs
 
 rootfs 使用 [buildroot](https://buildroot.org/) 工具进行编译。
@@ -62,22 +79,50 @@ $ git diff
 如果本地没有内核，先使用下面命令下载内核：
 
 ```bash
-$ make download-kernel-rpm
+$ make download-kernel-amd64-6-deb
+$ make download-kernel-arm6-deb
 
-$ ls kernel*
-kernel-ml-5.12.9-1.el7.elrepo.x86_64.rpm
+$ ls linux-image-6
+linux-image-6.1.0-13-amd64_6.1.55-1_amd64.deb
+linux-image-6.1.0-13-arm64_6.1.55-1_arm64.deb
 ```
 
 然后执行下面的命令进行 bundle：
 
 ```bash
+# bundle x86_64 物理机 pxe 启动的 initramfs
 $ make docker-bundle
 
-# 生成的文件会在 ./output_bundle
-$ ls output_bundle
-baremetal_prepare         bootx64.efi  intermediate  ldlinux.c32  libcom32.c32  menu.c32
-baremetal_prepare.tar.gz  chain.c32    isolinux.bin  ldlinux.e32  libutil.c32   pxelinux.0
-bootia32.efi              initramfs    kernel        ldlinux.e64  lpxelinux.0
+# bundle arm64 物理机 pxe 启动的 initramfs
+$ make docker-bundle-arm64
+
+# bundle x86_64 和arm64 轻量虚拟机的 initramfs
+$ make docker-bundle-vm
+```
+
+生成的文件会在 ./output_bundle* 目录，结构如下：
+
+- output_bundle: x86_64 物理机 pxe 启动
+- output_bundle_vm: x86_64 轻量级虚拟机启动
+- output_bundle_arm64: aarch64 物理机 pxe 启动
+- output_bundle_arm64_vm: aarch64 轻量级虚拟机启动
+
+```bash
+$ ls -alh output_bundle*/initramfs
+-rw-r--r-- 1 root root 71M Dec 14 14:03 output_bundle/initramfs
+-rw-r--r-- 1 root root 69M Dec 14 13:19 output_bundle_arm64/initramfs
+-rw-r--r-- 1 root root 43M Dec 14 13:37 output_bundle_arm64_vm/initramfs
+-rw-r--r-- 1 root root 45M Dec 14 13:36 output_bundle_vm/initramfs
+```
+
+### 将 initramfs 做成 yunionos 容器镜像
+
+```bash
+# 给物理机的镜像
+$ make docker-yunionos-image
+
+# 给虚拟机的镜像
+$ make docker-yunionos-image-vm
 ```
 
 ### 将 bundle 的文件做成 RPM

--- a/bin/mosbundle
+++ b/bin/mosbundle
@@ -20,7 +20,7 @@ Usage: ${0##*/} [-e EXTRA_MODULES_DIR] rootfs.tar kpkg.deb output_dir [iso|pxe] 
    [re]Bundle a buildroot rootfs into a mini-cloud image
 
    Example:
-    ${0##*/} [-e EXTRA_MODULES_DIR] rootfs.tar linux-image-*-virtuaal*.deb build-output/ [iso|pxe] [-f firmware_pkg] [-a]
+    ${0##*/} [-e EXTRA_MODULES_DIR] [-f firmware_pkg] [-a] [-r REMOVE_FILES_LIST_FILE] rootfs.tar linux-image-*-virtuaal*.deb build-output/ [iso|pxe]
 EOF
 }
 bad_Usage() { Usage 1>&2; fail "$@"; }
@@ -32,7 +32,7 @@ xrsync() {
 	rsync --archive --xattrs --hard-links --acls --sparse "$@"
 }
 
-short_opts="hvae:f:"
+short_opts="hvae:f:r:"
 long_opts="initrd-busybox:,help,verbose,all"
 getopt_out=$(getopt --name "${0##*/}" \
 	--options "${short_opts}" --long "${long_opts}" -- "$@") &&
@@ -51,6 +51,7 @@ while [ $# -ne 0 ]; do
 		-a|--all) all_modules=1;;
 		-e) extra_modules_in="$next";;
 		-f) firmware_in="$next";;
+		-r) remove_list_file="$next";;
 		--) shift; break;;
 	esac
 	shift;
@@ -58,7 +59,11 @@ done
 
 if [ -n "$extra_modules_in" ]; then
   extra_modules_dir=$(readlink -f "$extra_modules_in")
-  [ -d "$extra_modules_dir"  ] || bad_Usage "Extra modules dir: '$extra_modules_dir' not exists"
+  [ -d "$extra_modules_dir" ] || bad_Usage "Extra modules dir: '$extra_modules_dir' not exists"
+fi
+
+if [ -n "$remove_list_file" ]; then
+	[ -f "$remove_list_file" ]  || bad_Usage "Remove file list file: '$remove_list_file' doesn't exists"
 fi
 
 [ $# -ge 3 ] || bad_Usage "must give rootfs.tar, kernel pkg, out_dir, src_type{pxe|iso}"
@@ -296,6 +301,14 @@ xrsync "$stage_d/" "$initramfs_d" ||
 	fail "failed to copy to initramfs_d"
 rm -Rf "$initramfs_d/vmlinuz" "$initramfs_d/boot" ||
 	fail "failed to remove files in initramfs staging dir"
+
+# remove needless qemu dir which occupies 220M space
+if [ -f "$remove_list_file" ]; then
+	for dir in $(cat "$remove_list_file"); do
+		echo "RUN: rm -Rf "$initramfs_d/$dir""
+		rm -Rf $initramfs_d/$dir || fail "failed to remove $initramfs_d/$dir"
+	done
+fi
 
 ( cd "$initramfs_d" && find . | cpio --quiet -o -H newc |
     gzip -9 ) > "$initramfs"

--- a/remove_files_list.txt
+++ b/remove_files_list.txt
@@ -1,0 +1,2 @@
+usr/share/qemu
+usr/bin/qemu-system-*

--- a/scripts/bundle-run.sh
+++ b/scripts/bundle-run.sh
@@ -3,11 +3,16 @@
 BUILDROOT_IMG="registry.cn-beijing.aliyuncs.com/yunionio/buildroot:2021.08.2-0"
 
 TARGET_ARCH=${TARGET_ARCH:-x86_64}
+FOR_VM=${FOR_VM:-false}
 
 rule=bundle-pxe
 
 if [ $TARGET_ARCH == aarch64 ]; then
     rule=bundle-pxe-arm64
+fi
+
+if [ $FOR_VM == "true" ]; then
+    rule="$rule-vm"
 fi
 
 DEFAULT_CMD="make -C /yunionos $rule"

--- a/vm_remove_files_list.txt
+++ b/vm_remove_files_list.txt
@@ -1,0 +1,7 @@
+usr/share/qemu
+usr/bin/qemu-system-*
+opt/MegaRAID
+opt/adaptec
+opt/hp
+opt/lsi
+opt/mvcli


### PR DESCRIPTION
![img_v3_0264_12e97b9e-4eb2-4e87-805c-64042223a39g](https://github.com/yunionio/yunionos/assets/10767027/8fb2ec7a-02d1-4ed0-806c-c24907fdfeea)


这个原理很简单，就是添加了一个 remove_file_list 的文件，可以把要从 initramfs 里面删掉的路径写进来，然后 mosbundle 的时候就会根据这个文件内容 rm 相关目录文件。

最终测试裁剪后的 initramfs 能用 256MB 内存启动：

```bash
/usr/local/qemu-2.12.1/bin/qemu-system-x86_64 --enable-kvm -smp 1 -machine q35 -kernel ./output_bundle/kernel -initrd ./output_bundle_vm/initramfs -append 'rootfstype=ramfs'  -m 256  -vnc :2
```

![img_v3_0264_54faa120-ebed-46d4-8855-36a67694066g](https://github.com/yunionio/yunionos/assets/10767027/051c536c-ee3d-4c56-b1d5-5df46ed4f0b6)
