### PR TITLE
[feat][基于build-root 2021.08.02 升级e2fsprogs到1.47.0修复关于e2fsck版本低不支持新特性的问题]

### DIFF
--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -54,6 +54,10 @@ ENV O=/buildroot_output
 #VOLUME /root/buildroot/dl
 #VOLUME /buildroot_output
 
+# Copy package overrides for E2fsprogs 1.47.0
+COPY rootfs/package_overrides/e2fsprogs/e2fsprogs.mk /root/buildroot/package/e2fsprogs/
+COPY rootfs/package_overrides/e2fsprogs/e2fsprogs.hash /root/buildroot/package/e2fsprogs/
+
 RUN apt install -y rpm2cpio kmod
 
 RUN ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ KERNEL_ARM_5_DEB ?= linux-image-5.19.0-0.deb11.2-arm64_5.19.11-1~bpo11+1_arm64.d
 
 KERNEL_AMD64_5_DEB ?= linux-image-5.19.0-0.deb11.2-amd64_5.19.11-1~bpo11+1_amd64.deb
 
-KERNEL_ARM_6_DEB ?= linux-image-6.1.0-13-arm64_6.1.55-1_arm64.deb
+KERNEL_ARM_6_DEB ?= linux-image-6.1.0-32-arm64_6.1.129-1_arm64.deb
 
-KERNEL_AMD64_6_DEB ?= linux-image-6.1.0-13-amd64_6.1.55-1_amd64.deb
+KERNEL_AMD64_6_DEB ?= linux-image-6.1.0-32-amd64_6.1.129-1_amd64.deb
 
 # download-kernel-rpm:
 # 	wget -c https://mirror.rackspace.com/elrepo/kernel/el7/x86_64/RPMS/$(KERNEL_5_14_15_RPM)
@@ -49,7 +49,7 @@ pxelinux-update:
 	DOCKER_BUILDKIT=1 docker build -f Dockerfile.pxelinux --output ./pxelinux .
 
 buildroot-image:
-	docker build -t $(BUILD_ROOT_IMG) -f Dockerfile.buildroot-$(BUILD_ROOT_VERSION) .
+	docker build -t $(BUILD_ROOT_IMG) -f Dockerfile.buildroot .
 
 docker-buildroot:
 	#rm -rf $(BUILD_ROOT_OUTPUT_DIR)/target

--- a/rootfs/package_overrides/e2fsprogs/e2fsprogs.hash
+++ b/rootfs/package_overrides/e2fsprogs/e2fsprogs.hash
@@ -1,0 +1,6 @@
+# From https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.0/sha256sums.asc
+sha256  144af53f2bbd921cef6f8bea88bb9faddca865da3fbc657cc9b4d2001097d5db  e2fsprogs-1.47.0.tar.xz
+# Locally calculated
+sha256  5da5ef153e559c1d990d4c3eedbedd4442db892d37eae1f35fff069de8ec9020  NOTICE
+sha256  032989b508f1a72ebee5b3417e55d06d473f9ee203e45ab11864a7e49cdec63d  lib/ss/mit-sipb-copyright.h
+sha256  47182fe6631a32f271a15bbe210751b3825b7199f588879aac7d4804fc8b4b8f  lib/et/internal.h

--- a/rootfs/package_overrides/e2fsprogs/e2fsprogs.mk
+++ b/rootfs/package_overrides/e2fsprogs/e2fsprogs.mk
@@ -1,0 +1,103 @@
+################################################################################
+#
+# e2fsprogs
+#
+################################################################################
+
+E2FSPROGS_VERSION = 1.47.0
+E2FSPROGS_SOURCE = e2fsprogs-$(E2FSPROGS_VERSION).tar.xz
+E2FSPROGS_SITE = $(BR2_KERNEL_MIRROR)/linux/kernel/people/tytso/e2fsprogs/v$(E2FSPROGS_VERSION)
+E2FSPROGS_LICENSE = GPL-2.0, MIT-like with advertising clause (libss and libet)
+E2FSPROGS_LICENSE_FILES = NOTICE lib/ss/mit-sipb-copyright.h lib/et/internal.h
+E2FSPROGS_CPE_ID_VENDOR = e2fsprogs_project
+E2FSPROGS_INSTALL_STAGING = YES
+
+# 0001-libext2fs-add-sanity-check-to-extent-manipulation.patch
+E2FSPROGS_IGNORE_CVES += CVE-2022-1304
+
+# Use libblkid and libuuid from util-linux for host and target packages.
+# This prevents overriding them with e2fsprogs' ones, which may cause
+# problems for other packages.
+E2FSPROGS_DEPENDENCIES = host-pkgconf util-linux
+HOST_E2FSPROGS_DEPENDENCIES = host-pkgconf host-util-linux
+
+E2FSPROGS_SELINUX_MODULES = fstools
+
+# e4defrag doesn't build on older systems like RHEL5.x, and we don't
+# need it on the host anyway.
+# Disable fuse2fs as well to avoid carrying over deps, and it's unused
+HOST_E2FSPROGS_CONF_OPTS = \
+	--disable-defrag \
+	--disable-e2initrd-helper \
+	--disable-fuse2fs \
+	--disable-fsck \
+	--disable-libblkid \
+	--disable-libuuid \
+	--disable-testio-debug \
+	--enable-symlink-install \
+	--enable-elf-shlibs \
+	--with-crond-dir=no \
+	--with-udev-rules-dir=no \
+	--with-systemd-unit-dir=no
+
+# Set the binary directories to "/bin" and "/sbin", as busybox does,
+# so that we do not end up with two versions of e2fs tools.
+E2FSPROGS_CONF_OPTS = \
+	--bindir=/bin \
+	--sbindir=/sbin \
+	$(if $(BR2_STATIC_LIBS),--disable-elf-shlibs,--enable-elf-shlibs) \
+	$(if $(BR2_PACKAGE_E2FSPROGS_DEBUGFS),--enable-debugfs,--disable-debugfs) \
+	$(if $(BR2_PACKAGE_E2FSPROGS_E2IMAGE),--enable-imager,--disable-imager) \
+	$(if $(BR2_PACKAGE_E2FSPROGS_E4DEFRAG),--enable-defrag,--disable-defrag) \
+	$(if $(BR2_PACKAGE_E2FSPROGS_FSCK),--enable-fsck,--disable-fsck) \
+	$(if $(BR2_PACKAGE_E2FSPROGS_RESIZE2FS),--enable-resizer,--disable-resizer) \
+	--disable-uuidd \
+	--disable-libblkid \
+	--disable-libuuid \
+	--disable-e2initrd-helper \
+	--disable-testio-debug \
+	--disable-rpath \
+	--enable-symlink-install
+
+ifeq ($(BR2_PACKAGE_E2FSPROGS_FUSE2FS),y)
+E2FSPROGS_CONF_OPTS += --enable-fuse2fs
+E2FSPROGS_DEPENDENCIES += libfuse
+else
+E2FSPROGS_CONF_OPTS += --disable-fuse2fs
+endif
+
+ifeq ($(BR2_nios2),y)
+E2FSPROGS_CONF_ENV += ac_cv_func_fallocate=no
+endif
+
+E2FSPROGS_CONF_ENV += ac_cv_path_LDCONFIG=true
+
+HOST_E2FSPROGS_CONF_ENV += ac_cv_path_LDCONFIG=true
+
+E2FSPROGS_INSTALL_STAGING_OPTS = \
+	DESTDIR=$(STAGING_DIR) \
+	install-libs
+
+# e2scrub has no associated --enable/disable option
+ifneq ($(BR2_PACKAGE_E2FSPROGS_E2SCRUB),y)
+E2FSPROGS_MAKE_OPTS += E2SCRUB_DIR=
+endif
+
+E2FSPROGS_INSTALL_TARGET_OPTS = \
+	$(E2FSPROGS_MAKE_OPTS) \
+	DESTDIR=$(TARGET_DIR) \
+	install
+
+# Package does not build in parallel due to improper make rules
+define HOST_E2FSPROGS_INSTALL_CMDS
+	$(HOST_MAKE_ENV) $(MAKE1) -C $(@D) install install-libs
+endef
+
+# Remove compile_et which raises a build failure with samba4
+define HOST_E2FSPROGS_REMOVE_COMPILE_ET
+	$(RM) $(HOST_DIR)/bin/compile_et
+endef
+HOST_E2FSPROGS_POST_INSTALL_HOOKS += HOST_E2FSPROGS_REMOVE_COMPILE_ET
+
+$(eval $(autotools-package))
+$(eval $(host-autotools-package))


### PR DESCRIPTION
针对cloudpods部署裸金属服务器时，出现的 e2fsck 版本低的问题，通过在 build-root 2021.08.02 基础上升级 e2fsprogs 到 1.47.0 支持一些新的特性，解决无法创建磁盘分区的问题。